### PR TITLE
Fix app issues and add APK build workflow

### DIFF
--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -1,0 +1,60 @@
+name: Build Android APK
+
+on:
+  push:
+    branches: [ fix-app-issues ]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        
+      - name: Set up JDK 11
+        uses: actions/setup-java@v3
+        with:
+          java-version: '11'
+          distribution: 'temurin'
+          
+      - name: Setup Android SDK
+        uses: android-actions/setup-android@v2
+        
+      - name: Create google-services.json
+        run: |
+          mkdir -p app/src/main/assets
+          echo '${{ secrets.GOOGLE_SERVICES_JSON }}' > app/src/main/assets/google-services.json
+          
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+        
+      - name: Build with Gradle
+        run: ./gradlew assembleRelease
+        
+      - name: Upload APK
+        uses: actions/upload-artifact@v3
+        with:
+          name: app-release
+          path: app/build/outputs/apk/release/app-release.apk
+          
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: v1.0.${{ github.run_number }}
+          release_name: Release v1.0.${{ github.run_number }}
+          draft: false
+          prerelease: false
+          
+      - name: Upload Release Asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: app/build/outputs/apk/release/app-release.apk
+          asset_name: localmarket-app.apk
+          asset_content_type: application/vnd.android.package-archive

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -20,7 +20,7 @@ android {
     
     signingConfigs {
         release {
-            storeFile file("keystore/release.keystore")
+            storeFile file("release.keystore")
             storePassword "localmarket"
             keyAlias "localmarket"
             keyPassword "localmarket"


### PR DESCRIPTION
This PR fixes various issues in the Android app and adds a GitHub Actions workflow to build the APK.

Changes made:
1. Updated NetworkModule.kt to use HTTPS instead of HTTP
2. Added network_security_config.xml to handle HTTPS connections properly
3. Updated AndroidManifest.xml to use the network security configuration
4. Added GitHub Actions workflow to build and release the APK
5. Updated keystore configuration for app signing

To download the APK:
1. Go to the Actions tab in the repository
2. Click on the latest workflow run
3. Download the APK from the Artifacts section

Alternatively, you can download it from the Releases section after the workflow completes.